### PR TITLE
Move limit definitions to config file

### DIFF
--- a/config.json
+++ b/config.json
@@ -10,5 +10,25 @@
 
     // utils.hash_obj() of password for /admin/ page
     "admin_password" : "",
-    "admin_enable": false
+    "admin_enable": false,
+
+    // These all need to be ints, -1 for infinity
+    "limits" : {
+        "min_name" : 3,
+        "max_name" : 20,
+
+        "min_players": 3,
+        "max_players": 6,
+
+        "min_score": 1,
+        "max_score": -1,
+
+        "min_clue_length": 5,
+        "max_clue_length": 100000,
+
+        "max_message": 1024,
+
+        "min_user_name" : 3,
+        "max_user_name" : 25
+    }
 }

--- a/templates/main.html
+++ b/templates/main.html
@@ -40,22 +40,22 @@
             <tr>
                 <td><label>Name (optional)</label></td>
                 <td><input type="text" name="name" value=""
-                            minlength="{{ limits.MIN_NAME }}" maxlength="{{ limits.MAX_NAME }}" /></td>
+                            minlength="{{ limits.min_name }}" maxlength="{{ limits.max_name }}" /></td>
             </tr>
             <tr>
                 <td><label>Max Players</label></td>
                 <td><input type="text" name="max_players" value="6"
-                            min="{{ limits.MIN_PLAYERS }}" max="{{ limits.MAX_PLAYERS }}" size="4" required /></td>
+                            min="{{ limits.min_players }}" max="{{ limits.max_players }}" size="4" required /></td>
             </tr>
             <tr>
                 <td><label>Max Score (optional)</label></td>
                 <td><input type="text" name="max_score" value="30"
-                            min="{{ limits.MIN_SCORE }}" max="{{ limits.MAX_SCORE }}" size="4" /></td>
+                            min="{{ limits.min_score }}" max="{{ limits.max_score }}" size="4" /></td>
             </tr>
             <tr>
                 <td><label>Maximum Clue Length</label></td>
                 <td><input type="text" name="max_clue_length" value="1000"
-                            min="{{ limits.MIN_CLUE_LENGTH }}" max="{{ limits.MAX_CLUE_LENGTH }}" size="4" required /></td>
+                            min="{{ limits.min_clue_length }}" max="{{ limits.max_clue_length }}" size="4" required /></td>
             </tr>
             <tr>
                 <td><label>Deck Building</label></td>
@@ -142,7 +142,7 @@
 
     <div id="actionBox">
         <form id="actionForm">
-            <textarea id="actionClue" name="clue" cols="40" rows="4" minlength="{{ limits.MIN_CLUE_LENGTH }}">Enter clue here</textarea>
+            <textarea id="actionClue" name="clue" cols="40" rows="4" minlength="{{ limits.min_clue_length }}">Enter clue here</textarea>
             <div>
                 <input id="cardId" type="hidden" name="cid" value="" />
                 <input id="actionOk" type="submit" value="Ok" /> <button id="actionCancel">Cancel</button>

--- a/templates/main.js
+++ b/templates/main.js
@@ -242,7 +242,7 @@ $(document).ready(function() {
 
                 // Name of player and option to kick them if host
                 var canKick = data.isHost
-                           && (data.state == {{ states.BEGIN }} || numPlayers > {{ limits.MIN_PLAYERS }})
+                           && (data.state == {{ states.BEGIN }} || numPlayers > {{ limits.min_players }})
                            && data.state != {{ states.PLAY }}
                            && data.state != {{ states.VOTE }};
                 scoreBoard.push('<td class="player">'
@@ -304,7 +304,7 @@ $(document).ready(function() {
             }
             $('#joinGame').toggle();
             $('#startGame').toggle(data.state == {{ states.BEGIN }} && data.isHost
-                                && numPlayers >= {{ limits.MIN_PLAYERS }});
+                                && numPlayers >= {{ limits.min_players }});
 
             // Game configuration dependent stuff
             $('#clueTextarea').attr('maxlength', data.maxClueLength);

--- a/users.py
+++ b/users.py
@@ -6,11 +6,10 @@ import time
 class User(object):
     """Data for one user across multiple games."""
 
-    MIN_NAME = 3
-    MAX_NAME = 25
-
-    def __init__(self, uid, puid):
+    def __init__(self, limits, uid, puid):
         """Creates a new user with the given uid (private) and puid (public)."""
+        self.limits = limits
+
         self.uid = uid  # this id should never be exposed to the user
         self.puid = puid  # this id is exposed to all users
 
@@ -23,18 +22,19 @@ class User(object):
 
     def set_name(self, name):
         """Modifies the user's name."""
-        if len(name) >= self.MIN_NAME:
-            self.name = name[:self.MAX_NAME]
+        if len(name) >= self.limits.min_user_name:
+            self.name = name[:self.limits.max_user_name]
         return self.name
 
 
 class Users(object):
     """Data for all users."""
 
-    def __init__(self):
+    def __init__(self, limits):
         """Initializes an empty data structure."""
         self.users = {}
         self.users_by_puid = {}
+        self.limits = limits
 
     def __iter__(self):
         """Iterates over all User objects."""
@@ -54,7 +54,7 @@ class Users(object):
 
     def add_user(self, uid, puid):
         """Adds and returns a new user with a given private uid and puid."""
-        user = User(uid, puid)
+        user = User(self.limits, uid, puid)
         self.users[uid] = user
         self.users_by_puid[puid] = user
         return user


### PR DESCRIPTION
Some limits would make sense to make easier to configure. For example,
in some languages a one or two letter clue is perfectly sensible. Also,
these should be no assumptions for name, so lowering the minimum name
length should be easy.